### PR TITLE
Added new events to fix drawn annotation popup issue and modified click event to get correct callbacks

### DIFF
--- a/src/controls/annotation.js
+++ b/src/controls/annotation.js
@@ -246,8 +246,8 @@ export class AnnotationDrawControl
         }
     }
     
-    clearEvent()
-    //==========
+    clearFeature()
+    //============
     {
         this.__draw.deleteAll()
     }

--- a/src/controls/annotation.js
+++ b/src/controls/annotation.js
@@ -245,6 +245,12 @@ export class AnnotationDrawControl
             }
         }
     }
+    
+    clearEvent()
+    //==========
+    {
+        this.__draw.deleteAll()
+    }
 
     addFeature(feature)
     //=================

--- a/src/controls/annotation.js
+++ b/src/controls/annotation.js
@@ -96,6 +96,7 @@ export class AnnotationDrawControl
                 e.preventDefault();
             }
         }, false)
+        map.on('draw.modechange', this.featureModeChanged.bind(this))
         map.on('draw.create', this.createdFeature.bind(this))
         map.on('draw.delete', this.deletedFeature.bind(this))
         map.on('draw.update', this.updatedFeature.bind(this))
@@ -194,6 +195,12 @@ export class AnnotationDrawControl
                 this.#sendEvent('updated', feature)
             }
         }
+    }
+
+    featureModeChanged(event)
+    //=================
+    {
+        this.#sendEvent('modeChanged', event)
     }
 
     commitEvent(event)

--- a/src/controls/annotation.js
+++ b/src/controls/annotation.js
@@ -205,6 +205,12 @@ export class AnnotationDrawControl
         this.__uncommittedFeatureIds.delete(feature.id)
     }
 
+    abortEvent(event)
+    //===================
+    {
+        this.#sendEvent('aborted', event)
+    }
+
     rollbackEvent(event)
     //==================
     {

--- a/src/controls/annotation.js
+++ b/src/controls/annotation.js
@@ -146,7 +146,10 @@ export class AnnotationDrawControl
     #sendEvent(type, feature)
     //=======================
     {
-        this.__uncommittedFeatureIds.add(feature.id)
+        if (feature.id) {
+            // Add when the event is 'created', 'updated' or 'deleted'
+            this.__uncommittedFeatureIds.add(feature.id)
+        }
         this.__flatmap.annotationEvent(type, feature)
     }
 
@@ -208,6 +211,7 @@ export class AnnotationDrawControl
     abortEvent(event)
     //===================
     {
+        // Used as a flag to indicate the popup is closed
         this.#sendEvent('aborted', event)
     }
 

--- a/src/controls/annotation.js
+++ b/src/controls/annotation.js
@@ -198,8 +198,9 @@ export class AnnotationDrawControl
     }
 
     featureModeChanged(event)
-    //=================
+    //=======================
     {
+        // Used as a flag to indicate the feature mode
         this.#sendEvent('modeChanged', event)
     }
 
@@ -216,9 +217,10 @@ export class AnnotationDrawControl
     }
 
     abortEvent(event)
-    //===================
+    //===============
     {
         // Used as a flag to indicate the popup is closed
+        // Rollback should be performed when triggered 'aborted' event
         this.#sendEvent('aborted', event)
     }
 

--- a/src/flatmap-viewer.js
+++ b/src/flatmap-viewer.js
@@ -1114,11 +1114,11 @@ class FlatMap
     /**
      * Clear all drawn annotations from current annotation layer.
      */
-    clearAnnotationEvent()
-    //====================
+    clearAnnotationFeature()
+    //======================
     {
         if (this._userInteractions) {
-            this._userInteractions.clearAnnotationEvent()
+            this._userInteractions.clearAnnotationFeature()
         }
     }
 

--- a/src/flatmap-viewer.js
+++ b/src/flatmap-viewer.js
@@ -1110,6 +1110,17 @@ class FlatMap
             this._userInteractions.rollbackAnnotationEvent(event)
         }
     }
+  
+    /**
+     * Clear all drawn annotations from current annotation layer.
+     */
+    clearAnnotationEvent()
+    //====================
+    {
+        if (this._userInteractions) {
+            this._userInteractions.clearAnnotationEvent()
+        }
+    }
 
     /**
      * Add a drawn feature to the annotation drawing tool.

--- a/src/interactions.js
+++ b/src/interactions.js
@@ -340,6 +340,14 @@ export class UserInteractions
         }
     }
 
+    abortAnnotationEvent(event)
+    //==========================
+    {
+        if (this.#annotationDrawControl) {
+            this.#annotationDrawControl.abortEvent(event)
+        }
+    }
+
     rollbackAnnotationEvent(event)
     //==========================
     {
@@ -835,7 +843,16 @@ export class UserInteractions
             }
             this.setModal_();
             this._currentPopup = new maplibregl.Popup(options).addTo(this._map);
-            this._currentPopup.on('close', this.__onCloseCurrentPopup.bind(this));
+            this._currentPopup.on('close', () => {
+                this.__onCloseCurrentPopup.bind(this)
+                if (drawn) {
+                    this.abortAnnotationEvent({
+                        featureId: featureId,
+                        content: content,
+                        ...options
+                    })
+                }
+            });
             this._currentPopup.setLngLat(location);
             if (typeof content === 'object') {
                 this._currentPopup.setDOMContent(content);

--- a/src/interactions.js
+++ b/src/interactions.js
@@ -1176,7 +1176,7 @@ export class UserInteractions
             this.unselectFeatures();
             return;
         }
-        const clickedFeature = clickedFeatures[0];
+        const clickedFeature = clickedFeatures.filter((f)=>f.id)[0];
         this.selectionEvent_(event.originalEvent, clickedFeature);
         if (this._modal) {
             // Remove tooltip, reset active features, etc

--- a/src/interactions.js
+++ b/src/interactions.js
@@ -357,6 +357,14 @@ export class UserInteractions
         }
     }
 
+    clearAnnotationEvent()
+    //====================
+    {
+        if (this.#annotationDrawControl) {
+            this.#annotationDrawControl.clearEvent()
+        }
+    }
+
     addAnnotationFeature(feature)
     //===========================
     {

--- a/src/interactions.js
+++ b/src/interactions.js
@@ -357,11 +357,11 @@ export class UserInteractions
         }
     }
 
-    clearAnnotationEvent()
-    //====================
+    clearAnnotationFeature()
+    //======================
     {
         if (this.#annotationDrawControl) {
-            this.#annotationDrawControl.clearEvent()
+            this.#annotationDrawControl.clearFeature()
         }
     }
 

--- a/src/interactions.js
+++ b/src/interactions.js
@@ -341,7 +341,7 @@ export class UserInteractions
     }
 
     abortAnnotationEvent(event)
-    //==========================
+    //=========================
     {
         if (this.#annotationDrawControl) {
             this.#annotationDrawControl.abortEvent(event)
@@ -349,7 +349,7 @@ export class UserInteractions
     }
 
     rollbackAnnotationEvent(event)
-    //==========================
+    //============================
     {
         if (this.#annotationDrawControl) {
             this.#annotationDrawControl.rollbackEvent(event)
@@ -828,7 +828,9 @@ export class UserInteractions
                && this.__lastClickLngLat !== null) {
                 location = this.__lastClickLngLat;
             } else if (drawn) {
-                location = options.annotationFeatureGeometry; // Popup at the centroid of the feature
+                // Popup at the centroid of the feature
+                // Calculated with the feature geometry coordinates
+                location = options.annotationFeatureGeometry;
             } else {
                 // Position popup at the feature's 'centre'
                 location = this.__markerPosition(featureId, ann);

--- a/src/interactions.js
+++ b/src/interactions.js
@@ -788,28 +788,31 @@ export class UserInteractions
     //=======================================
     {
         const ann = this._flatmap.annotation(featureId);
-        if (ann) {  // The feature exists
+        const drawn = options && options.annotationFeatureGeometry
+        if (ann || drawn) {  // The feature exists or it is a drawn annotation
+            if (ann) {
+                
+                // Remove any existing popup
 
-            // Remove any existing popup
-
-            if (this._currentPopup) {
-                if (options && options.preserveSelection) {
-                    this._currentPopup.options.preserveSelection = options.preserveSelection;
+                if (this._currentPopup) {
+                    if (options && options.preserveSelection) {
+                        this._currentPopup.options.preserveSelection = options.preserveSelection;
+                    }
+                    this._currentPopup.remove();
                 }
-                this._currentPopup.remove();
+
+                // Clear selection if we are not preserving it
+
+                if (options && options.preserveSelection) {
+                    delete options.preserveSelection;       // Don't pass to onClose()
+                } else {                                    // via the popup's options
+                    this.unselectFeatures();
+                }
+
+                // Select the feature
+
+                this.selectFeature(featureId);
             }
-
-            // Clear selection if we are not preserving it
-
-            if (options && options.preserveSelection) {
-                delete options.preserveSelection;       // Don't pass to onClose()
-            } else {                                    // via the popup's options
-                this.unselectFeatures();
-            }
-
-            // Select the feature
-
-            this.selectFeature(featureId);
 
             // Find the pop-up's postion
 
@@ -818,6 +821,8 @@ export class UserInteractions
                && options.positionAtLastClick
                && this.__lastClickLngLat !== null) {
                 location = this.__lastClickLngLat;
+            } else if (drawn) {
+                location = options.annotationFeatureGeometry
             } else {
                 // Position popup at the feature's 'centre'
                 location = this.__markerPosition(featureId, ann);

--- a/src/interactions.js
+++ b/src/interactions.js
@@ -268,6 +268,7 @@ export class UserInteractions
         // Handle mouse events
 
         this._map.on('click', this.clickEvent_.bind(this));
+        this._map.on('touchend', this.clickEvent_.bind(this));
         this._map.on('mousemove', this.mouseMoveEvent_.bind(this));
         this._lastFeatureMouseEntered = null;
         this._lastFeatureModelsMouse = null;

--- a/src/interactions.js
+++ b/src/interactions.js
@@ -1186,6 +1186,7 @@ export class UserInteractions
             return;
         }
         const clickedFeature = clickedFeatures.filter((f)=>f.id)[0];
+        const clickedDrawnFeature = clickedFeatures.filter((f)=>!f.id)[0];
         this.selectionEvent_(event.originalEvent, clickedFeature);
         if (this._modal) {
             // Remove tooltip, reset active features, etc
@@ -1198,6 +1199,8 @@ export class UserInteractions
             if ('properties' in clickedFeature && 'hyperlink' in clickedFeature.properties) {
                 window.open(clickedFeature.properties.hyperlink, '_blank');
             }
+        } else if (clickedDrawnFeature !== undefined) {
+            this.__featureEvent('click', clickedDrawnFeature);
         }
     }
 


### PR DESCRIPTION
A few more things have been added/modified:

1. Added the event handler for the `draw.modechange` event and the `modeChanged` event. It tracks the state change while creating/clicking dawn annotations.
2. Added the `aborted` event. It will help to indicate the popup window is closed.
3. Modified the `showPopup` function to fix the drawn annotation popup. Pass new attribute `annotationFeatureGeometry` in options. `annotationFeatureGeometry` is the central geo coordinate for the drawn annotation.

4. Added the clear feature function, which is used to switch the display of different types of drawn annotation.

Below is related to displaying relevant features while creating(maybe also updating/deleting) new annotations (A request from Andre).
5. Modified 'this.clickEvent_' function to fix can only click on the annotation layer issue when starting drawing. This shows relevant features while drawing connectivities or points.
6. Binded 'touchend' event to 'this.clickEvent_'. This fixed the no-callback event issue in the tablet browser(touch screen).