### PR TITLE
Fix for features coincide situdation

### DIFF
--- a/src/controls/annotation.js
+++ b/src/controls/annotation.js
@@ -78,6 +78,7 @@ export class AnnotationDrawControl
             keybindings: true
         })
         this.__map = null
+        this.__inDrawing = false
     }
 
     onAdd(map)
@@ -96,7 +97,7 @@ export class AnnotationDrawControl
                 e.preventDefault();
             }
         }, false)
-        map.on('draw.modechange', this.featureModeChanged.bind(this))
+        map.on('draw.modechange', this.modeChangedEvent.bind(this))
         map.on('draw.create', this.createdFeature.bind(this))
         map.on('draw.delete', this.deletedFeature.bind(this))
         map.on('draw.update', this.updatedFeature.bind(this))
@@ -197,11 +198,22 @@ export class AnnotationDrawControl
         }
     }
 
-    featureModeChanged(event)
-    //=======================
+    modeChangedEvent(event)
+    //=====================
     {
         // Used as a flag to indicate the feature mode
+        if (event.mode.startsWith('draw')) {
+            this.__inDrawing = true
+        } else {
+            this.__inDrawing = false
+        }
         this.#sendEvent('modeChanged', event)
+    }
+
+    inDrawingMode()
+    //=============
+    {
+        return this.__inDrawing
     }
 
     commitEvent(event)

--- a/src/controls/annotation.js
+++ b/src/controls/annotation.js
@@ -202,11 +202,7 @@ export class AnnotationDrawControl
     //=====================
     {
         // Used as a flag to indicate the feature mode
-        if (event.mode.startsWith('draw')) {
-            this.__inDrawing = true
-        } else {
-            this.__inDrawing = false
-        }
+        this.__inDrawing = (event.mode.startsWith('draw'))
         this.#sendEvent('modeChanged', event)
     }
 

--- a/src/interactions.js
+++ b/src/interactions.js
@@ -333,6 +333,14 @@ export class UserInteractions
         }
     }
 
+    inDrawingAnnotationMode()
+    //=======================
+    {
+        if (this.#annotationDrawControl) {
+            return this.#annotationDrawControl.inDrawingMode()
+        }
+    }
+
     commitAnnotationEvent(event)
     //==========================
     {

--- a/src/interactions.js
+++ b/src/interactions.js
@@ -1193,22 +1193,25 @@ export class UserInteractions
             this.unselectFeatures();
             return;
         }
-        const clickedFeature = clickedFeatures.filter((f)=>f.id)[0];
-        const clickedDrawnFeature = clickedFeatures.filter((f)=>!f.id)[0];
+        const inDrawing = this.inDrawingAnnotationMode()
+        const clickedDrawnFeature = clickedFeatures.filter((f) => !f.id)[0];
+        const clickedFeature = clickedFeatures.filter((f) => f.id)[0];
         this.selectionEvent_(event.originalEvent, clickedFeature);
         if (this._modal) {
             // Remove tooltip, reset active features, etc
             this.__resetFeatureDisplay();
             this.unselectFeatures();
             this.__clearModal();
+        } else if (clickedDrawnFeature !== undefined && !inDrawing) {
+            // When feature and drawn feature are coinciding, click on annotation layer by default
+            // While in drawing, DISABLE 'click' event on annotation layer
+            this.__featureEvent('click', clickedDrawnFeature);
         } else if (clickedFeature !== undefined) {
             this.__lastClickLngLat = event.lngLat;
             this.__featureEvent('click', clickedFeature);
             if ('properties' in clickedFeature && 'hyperlink' in clickedFeature.properties) {
                 window.open(clickedFeature.properties.hyperlink, '_blank');
             }
-        } else if (clickedDrawnFeature !== undefined) {
-            this.__featureEvent('click', clickedDrawnFeature);
         }
     }
 

--- a/src/interactions.js
+++ b/src/interactions.js
@@ -1202,11 +1202,11 @@ export class UserInteractions
             this.__resetFeatureDisplay();
             this.unselectFeatures();
             this.__clearModal();
-        } else if (clickedDrawnFeature !== undefined && !inDrawing) {
+        } else if (clickedDrawnFeature && !inDrawing) {
             // When feature and drawn feature are coinciding, click on annotation layer by default
             // While in drawing, DISABLE 'click' event on annotation layer
             this.__featureEvent('click', clickedDrawnFeature);
-        } else if (clickedFeature !== undefined) {
+        } else if (clickedFeature) {
             this.__lastClickLngLat = event.lngLat;
             this.__featureEvent('click', clickedFeature);
             if ('properties' in clickedFeature && 'hyperlink' in clickedFeature.properties) {


### PR DESCRIPTION
This is a quick fix for the annotation and flatmap layer click callback events.

- Added an `indrawing` status.
- Added new functions to return the `indrawing` status.
- Reorder click callback events - click callback only on the annotation layer if drawn annotation exists on click point.
- Disable the click callback event on the annotation layer while `indrawing`.