### PR TITLE
Added new annotator callbacks and functions

### DIFF
--- a/src/controls/annotation.js
+++ b/src/controls/annotation.js
@@ -190,6 +190,8 @@ export class AnnotationDrawControl
     //===================
     {
         const feature = this.#cleanFeature(event)
+        // specify updated callback type, either `move` or `change_coordinates`
+        feature.action = event.action
         if (feature) {
             if (this.__uncommittedFeatureIds.has(feature.id)) {
                 // Ignore updates on an uncommitted create or update

--- a/src/controls/annotation.js
+++ b/src/controls/annotation.js
@@ -190,9 +190,9 @@ export class AnnotationDrawControl
     //===================
     {
         const feature = this.#cleanFeature(event)
-        // specify updated callback type, either `move` or `change_coordinates`
-        feature.action = event.action
         if (feature) {
+            // specify updated callback type, either `move` or `change_coordinates`
+            feature.action = event.action
             if (this.__uncommittedFeatureIds.has(feature.id)) {
                 // Ignore updates on an uncommitted create or update
             } else {

--- a/src/controls/annotation.js
+++ b/src/controls/annotation.js
@@ -270,6 +270,12 @@ export class AnnotationDrawControl
         this.__draw.deleteAll()
     }
 
+    trashFeature()
+    //============
+    {
+        this.__draw.trash()
+    }
+
     addFeature(feature)
     //=================
     {

--- a/src/controls/annotation.js
+++ b/src/controls/annotation.js
@@ -290,11 +290,6 @@ export class AnnotationDrawControl
     {
         // Change the mode directly without listening to modes callback
         this.__draw.changeMode(type.mode, type.options)
-        // Fire `trash` action
-        // `simple_select` for delete and `direct_select` for edit
-        if (type.mode === 'simple_select' || type.mode === 'direct_select') {
-            this.__draw.trash()
-        }
     }
 }
 

--- a/src/controls/annotation.js
+++ b/src/controls/annotation.js
@@ -284,6 +284,18 @@ export class AnnotationDrawControl
     {
         return this.__draw.get(feature.id) || null
     }
+
+    changeMode(type)
+    //===============
+    {
+        // Change the mode directly without listening to modes callback
+        this.__draw.changeMode(type.mode, type.options)
+        // Fire `trash` action
+        // `simple_select` for delete and `direct_select` for edit
+        if (type.mode === 'simple_select' || type.mode === 'direct_select') {
+            this.__draw.trash()
+        }
+    }
 }
 
 //==============================================================================

--- a/src/controls/annotation.js
+++ b/src/controls/annotation.js
@@ -101,6 +101,7 @@ export class AnnotationDrawControl
         map.on('draw.create', this.createdFeature.bind(this))
         map.on('draw.delete', this.deletedFeature.bind(this))
         map.on('draw.update', this.updatedFeature.bind(this))
+        map.on('draw.selectionchange', this.selectionChangedEvent.bind(this))
         this.show(this.__visible)
         return this.__container
     }
@@ -204,6 +205,13 @@ export class AnnotationDrawControl
         // Used as a flag to indicate the feature mode
         this.__inDrawing = (event.mode.startsWith('draw'))
         this.#sendEvent('modeChanged', event)
+    }
+
+    selectionChangedEvent(event)
+    //==========================
+    {
+        // Used to indicate a feature is selected or deselected
+        this.#sendEvent('selectionChanged', event)
     }
 
     inDrawingMode()

--- a/src/flatmap-viewer.js
+++ b/src/flatmap-viewer.js
@@ -1123,6 +1123,17 @@ class FlatMap
     }
 
     /**
+     * Fire trash to enter `updated` or `deleted` feature event.
+     */
+    trashAnnotationFeature()
+    //======================
+    {
+        if (this._userInteractions) {
+            this._userInteractions.trashAnnotationFeature()
+        }
+    }
+
+    /**
      * Add a drawn feature to the annotation drawing tool.
      *
      * @param feature    {Object}        The feature to add

--- a/src/flatmap-viewer.js
+++ b/src/flatmap-viewer.js
@@ -1156,6 +1156,24 @@ class FlatMap
     }
 
     /**
+     * Changes draw to another mode. The mode argument must be one of the following:
+     * `simple_select`, `direct_select`, `draw_line_string`,
+     * `draw_polygon` or `draw_point`. Options is accepted in first three modes.
+     * More details in mapbox-gl-draw github repository.
+     *
+     * @param type      {Object}     The object 
+     * @param type.mode {string}     Either ``simple_select``, ``direct_select``, etc
+     * @param type.options {Object}  Feature id(s) object.
+     */
+    changeAnnotationDrawMode(type)
+    //============================
+    {
+        if (this._userInteractions) {
+            this._userInteractions.changeAnnotationDrawMode(type)
+        }
+    }
+
+    /**
      * Generate a callback as a result of some event with a flatmap feature.
      *
      * @param      {string}  eventType     The event type

--- a/src/interactions.js
+++ b/src/interactions.js
@@ -373,6 +373,14 @@ export class UserInteractions
         }
     }
 
+    trashAnnotationFeature()
+    //======================
+    {
+        if (this.#annotationDrawControl) {
+            this.#annotationDrawControl.trashFeature()
+        }
+    }
+
     addAnnotationFeature(feature)
     //===========================
     {

--- a/src/interactions.js
+++ b/src/interactions.js
@@ -389,6 +389,14 @@ export class UserInteractions
         }
     }
 
+    changeAnnotationDrawMode(type)
+    //=============================
+    {
+        if (this.#annotationDrawControl) {
+            this.#annotationDrawControl.changeMode(type)
+        }
+    }
+
     __setupAnnotation()
     //=================
     {

--- a/src/main.js
+++ b/src/main.js
@@ -64,7 +64,7 @@ class DrawControl
     //================
     {
         console.log(event)
-        if (this._idField) {
+        if (this._idField && event.type !== 'modeChanged' && event.type !== 'selectionChanged') {
             this._idField.innerText = `Annotation ${event.type}, Id: ${event.feature.id}`
             this._lastEvent = event
         }


### PR DESCRIPTION
Three main things are added:
1. Added `selectionChanged` callback to check if any feature is selected.
2. Added `changeAnnotationDrawMode` to force change the `Draw` mode. Which provides the `edit`/`delete` mode for the annotator.
3. Added `trashAnnotationFeature` function to fire `changeAnnotationDrawMode` function when the mode is '*_select'.