### PR TITLE
Existing drawn features connectivity

### DIFF
--- a/src/controls/annotation.js
+++ b/src/controls/annotation.js
@@ -78,7 +78,6 @@ export class AnnotationDrawControl
             keybindings: true
         })
         this.__map = null
-        this.__inDrawing = false
     }
 
     onAdd(map)
@@ -204,8 +203,7 @@ export class AnnotationDrawControl
     modeChangedEvent(event)
     //=====================
     {
-        // Used as a flag to indicate the feature mode
-        this.__inDrawing = (event.mode.startsWith('draw'))
+        // Used to indicate the feature mode changes
         this.#sendEvent('modeChanged', event)
     }
 
@@ -214,12 +212,6 @@ export class AnnotationDrawControl
     {
         // Used to indicate a feature is selected or deselected
         this.#sendEvent('selectionChanged', event)
-    }
-
-    inDrawingMode()
-    //=============
-    {
-        return this.__inDrawing
     }
 
     commitEvent(event)

--- a/src/interactions.js
+++ b/src/interactions.js
@@ -1199,7 +1199,7 @@ export class UserInteractions
             return;
         }
         const inDrawing = this.inDrawingAnnotationMode()
-        const clickedDrawnFeature = clickedFeatures.filter((f) => !f.id)[0];
+        const clickedDrawnFeatures = clickedFeatures.filter((f) => !f.id);
         const clickedFeature = clickedFeatures.filter((f) => f.id)[0];
         this.selectionEvent_(event.originalEvent, clickedFeature);
         if (this._modal) {
@@ -1207,10 +1207,16 @@ export class UserInteractions
             this.__resetFeatureDisplay();
             this.unselectFeatures();
             this.__clearModal();
-        } else if (clickedDrawnFeature && !inDrawing) {
-            // When feature and drawn feature are coinciding, click on annotation layer by default
-            // While in drawing, DISABLE 'click' event on annotation layer
-            this.__featureEvent('click', clickedDrawnFeature);
+        } else if (clickedDrawnFeatures.length > 0) {
+            // Layer of existing drawn features
+            const clickedOnColdLayer = clickedDrawnFeatures.filter((f) => f.source === 'mapbox-gl-draw-cold')[0];
+            // Layer of currently drawing feature
+            const clickedOnHotLayer = clickedDrawnFeatures.filter((f) => f.source === 'mapbox-gl-draw-hot')[0];
+            this.__featureEvent('click',
+                clickedOnColdLayer ?
+                    clickedOnColdLayer : clickedFeature ?
+                        clickedFeature : clickedOnHotLayer
+            );
         } else if (clickedFeature) {
             this.__lastClickLngLat = event.lngLat;
             this.__featureEvent('click', clickedFeature);

--- a/src/interactions.js
+++ b/src/interactions.js
@@ -337,14 +337,6 @@ export class UserInteractions
         }
     }
 
-    inDrawingAnnotationMode()
-    //=======================
-    {
-        if (this.#annotationDrawControl) {
-            return this.#annotationDrawControl.inDrawingMode()
-        }
-    }
-
     commitAnnotationEvent(event)
     //==========================
     {
@@ -1198,7 +1190,6 @@ export class UserInteractions
             this.unselectFeatures();
             return;
         }
-        const inDrawing = this.inDrawingAnnotationMode()
         const clickedDrawnFeatures = clickedFeatures.filter((f) => !f.id);
         const clickedFeature = clickedFeatures.filter((f) => f.id)[0];
         this.selectionEvent_(event.originalEvent, clickedFeature);


### PR DESCRIPTION
This PR focuses on Alan's new requirement 

- to provide the ability to create connectivity between existing drawn features.

e.g.
<img width="500" alt="Screenshot 2024-05-20 at 4 39 51 PM" src="https://github.com/AnatomicMaps/flatmap-viewer/assets/87633683/170e2931-7f50-4c2d-8f2d-688f520326d0">

The main change here is to modify the click callback order based on the existing layers.