### PR TITLE
Update functionality to find featureId using anatomicalId which also checking proxies #45

### DIFF
--- a/src/flatmap-viewer.js
+++ b/src/flatmap-viewer.js
@@ -112,6 +112,7 @@ export class FlatMap
     #mapTermGraph
     #startupState = -1
     #taxonNames = new Map()
+    #proxies
 
     constructor(container, mapServer, mapDescription, resolve)
     {
@@ -140,6 +141,7 @@ export class FlatMap
         this.__taxonToFeatureIds = new Map();
         this.__featurePropertyValues = new Map()
         this.#mapTermGraph = new MapTermGraph(mapDescription.sparcTermGraph)
+        this.#proxies = mapDescription.proxies;
 
         const sckanProvenance = mapDescription.details.connectivity
         if (sckanProvenance === undefined) {
@@ -728,8 +730,18 @@ export class FlatMap
     modelFeatureIds(anatomicalId)
     //===========================
     {
-        const featureIds = this.__modelToFeatureIds.get(utils.normaliseId(anatomicalId));
-        return featureIds ? featureIds : [];
+        const normalisedId = utils.normaliseId(anatomicalId);
+        let featureIds = this.__modelToFeatureIds.get(normalisedId);
+        if (!featureIds) {
+            featureIds = [];
+            if (this.#proxies.hasOwnProperty(normalisedId)) {
+                const proxies = this.#proxies[normalisedId];
+                for (const proxy of proxies) {
+                    featureIds.push(...this.modelFeatureIds(proxy));
+                }
+            }
+        }
+        return featureIds
     }
 
     modelFeatureIdList(anatomicalIds)

--- a/src/flatmap-viewer.js
+++ b/src/flatmap-viewer.js
@@ -2183,6 +2183,16 @@ export class MapManager
 
                 const provenance = await this._mapServer.loadJSON(`flatmap/${mapId}/metadata`);
 
+                // Get the map's proxy features
+
+                const proxyFeatures = await this._mapServer.loadJSON(`flatmap/${mapId}/proxies`);
+                const proxies = Array.isArray(proxyFeatures)
+                    ? proxyFeatures.reduce((acc, item) => {
+                        acc[item.feature] = item.proxies;
+                        return acc;
+                    }, {})
+                    : {};
+
                 // Set zoom range if not specified as an option
 
                 if ('vector-tiles' in mapStyle.sources) {
@@ -2234,7 +2244,8 @@ export class MapManager
                         pathways: pathways,
                         provenance, provenance,
                         callback: callback,
-                        sparcTermGraph: this.#sparcTermGraph
+                        sparcTermGraph: this.#sparcTermGraph,
+                        proxies: proxies
                     },
                     resolve);
 


### PR DESCRIPTION
This PR updates the `modelFeatureIds` function in `Flatmap` to also look in proxies if it is not in `__modelToFeatureIds`. #45 