### PR TITLE
Fix keyboard zoom feature

### DIFF
--- a/src/interactions.js
+++ b/src/interactions.js
@@ -1696,10 +1696,12 @@ export class UserInteractions
         }
         if (type === 'zoom') {
             if ('originalEvent' in event) {
-                this.#updateActiveFeature([
-                    event.originalEvent.layerX,
-                    event.originalEvent.layerY
-                ])
+                if ('layerX' in event.originalEvent && 'layerY' in event.originalEvent) {
+                    this.#updateActiveFeature([
+                        event.originalEvent.layerX,
+                        event.originalEvent.layerY
+                    ])
+                }
             }
             this._layerManager.zoomEvent()
         }


### PR DESCRIPTION
Keyboard zoom currently does not work as expected. 

The keyboard zoom event does not contain `layerX` and `layerY`, function will stop at `#updateActiveFeature`. The rest of keyboard events (rotate, and pan the map) will be affected and become unavailable.

The fix makes sure `#updateActiveFeature` only be fired when `layerX` and `layerY` exist.