### PR TITLE
Add removePopup method to close active popup programmatically

### DIFF
--- a/src/flatmap-viewer.js
+++ b/src/flatmap-viewer.js
@@ -968,6 +968,14 @@ export class FlatMap
         }
     }
 
+    removePopup()
+    //===========
+    {
+        if (this._userInteractions !== null) {
+            this._userInteractions.removePopup();
+        }
+    }
+
     setPaint(options=null)
     //====================
     {
@@ -1393,7 +1401,7 @@ export class FlatMap
             this._userInteractions.rollbackAnnotationEvent(event)
         }
     }
-  
+
     /**
      * Clear all drawn annotations from current annotation layer.
      */
@@ -1455,7 +1463,7 @@ export class FlatMap
      * `draw_polygon` or `draw_point`. Options is accepted in first three modes.
      * More details in mapbox-gl-draw github repository.
      *
-     * @param type      {Object}     The object 
+     * @param type      {Object}     The object
      * @param type.mode {string}     Either ``simple_select``, ``direct_select``, etc
      * @param type.options {Object}  Feature id(s) object.
      */

--- a/src/flatmap-viewer.js
+++ b/src/flatmap-viewer.js
@@ -968,6 +968,9 @@ export class FlatMap
         }
     }
 
+    /**
+     * Remove the currently active popup from the map.
+     */
     removePopup()
     //===========
     {

--- a/src/interactions.js
+++ b/src/interactions.js
@@ -947,6 +947,9 @@ export class UserInteractions
         }
     }
 
+    /**
+     * Remove the currently active popup from the map.
+     */
     removePopup()
     //===========
     {

--- a/src/interactions.js
+++ b/src/interactions.js
@@ -947,6 +947,15 @@ export class UserInteractions
         }
     }
 
+    removePopup()
+    //===========
+    {
+        if (this._currentPopup) {
+            this._currentPopup.remove();
+            this._currentPopup = null;
+        }
+    }
+
     lineTooltip_(lineFeatures)
     //========================
     {


### PR DESCRIPTION
A popup (tooltip) can be shown programmatically using the `showPopup` method, but it cannot be closed programmatically.