### PR TITLE
Modify highlighting

### DIFF
--- a/src/flatmap-viewer.js
+++ b/src/flatmap-viewer.js
@@ -1675,7 +1675,7 @@ export class FlatMap
         });
         if (this._userInteractions !== null) {
             const featureIds = this.modelFeatureIdList(externalIds);
-            this._userInteractions.zoomToFeatures(featureIds, options);
+            return this._userInteractions.zoomToFeatures(featureIds, options);
         }
     }
 
@@ -1721,7 +1721,7 @@ export class FlatMap
             padding:100
         })
         if (this._userInteractions !== null) {
-            this._userInteractions.zoomToFeatures(geojsonIds, options)
+            return this._userInteractions.zoomToFeatures(geojsonIds, options)
         }
     }
 

--- a/src/interactions.js
+++ b/src/interactions.js
@@ -814,7 +814,7 @@ export class UserInteractions
     //===========================
     {
         this.unselectFeatures();
-        this.zoomToFeatures(featureIds, {noZoomIn: true});
+        this.zoomToFeatures(featureIds);
     }
 
     /**

--- a/src/interactions.js
+++ b/src/interactions.js
@@ -828,11 +828,12 @@ export class UserInteractions
     //======================================
     {
         options = utils.setDefaults(options, {
-            zoomIn: false
+            zoomIn: false,
+            sequence: false
         });
         if (featureIds.length) {
-            this.unselectFeatures();
-            let bbox = null;
+            if (!options.sequence) this.unselectFeatures();
+            let bbox = null || options.bbox;
             if (!options.zoomIn) {
                 const bounds = this._map.getBounds().toArray();
                 bbox = [...bounds[0], ...bounds[1]];
@@ -858,6 +859,7 @@ export class UserInteractions
                     padding: 0,
                     animate: false
                 })
+                return bbox
             }
         }
     }

--- a/src/interactions.js
+++ b/src/interactions.js
@@ -823,6 +823,7 @@ export class UserInteractions
      * @param      {Array.<string>}  featureIds   An array of feature identifiers
      * @param      {Object}  [options]
      * @param      {boolean} [options.zoomIn=false]  Zoom in the map (always zoom out as necessary)
+     * @param      {boolean} [options.sequence=false] Select features in chunks (optional for large sets of features)
      */
     zoomToFeatures(featureIds, options=null)
     //======================================


### PR DESCRIPTION
The changes here are for the ticket - [Improve Flatmap highlight/selection speed](https://www.wrike.com/open.htm?id=1589847586)

- `options.sequence` is added to make sure the selected features will remain.
- `bbox` is returned and passed in to make sure the bounds will always fit.

Currently, there is a short time delay when highlighting a large number of features. Allowing highlighting neuron paths by chunk should be able to minimize the time delay from paths selected to paths highlighted. Although the total time cost may remain the same.