### PR TITLE
Fix coloured and outlined options in setPaint

### DIFF
--- a/src/flatmap.ts
+++ b/src/flatmap.ts
@@ -1182,8 +1182,8 @@ export class FlatMap
     //==================
     {
         options = utils.setDefaults(options, {
-            colour: true,
-            outline: true
+            coloured: true,
+            outlined: true
         })
         if (this.#userInteractions !== null) {
             this.#userInteractions.setPaint(options)

--- a/src/interactions.ts
+++ b/src/interactions.ts
@@ -200,7 +200,7 @@ export class UserInteractions
         this.#map = flatmap.map!
 
         // Default colour settings
-        this.#colourOptions = {colour: true, outline: true}
+        this.#colourOptions = {coloured: true, outlined: true}
 
         // Track enabled features
 

--- a/src/layers/index.ts
+++ b/src/layers/index.ts
@@ -368,7 +368,7 @@ class FlatMapStylingLayer
     #setPaintRasterLayers(options)
     //============================
     {
-        const coloured = !('colour' in options) || options.colour
+        const coloured = !('coloured' in options) || options.coloured
         for (const layer of this.#rasterStyleLayers) {
             // Check active status when resetting to visible....
             this.#map.setLayoutProperty(layer.id, 'visibility',

--- a/src/layers/styling.ts
+++ b/src/layers/styling.ts
@@ -330,7 +330,7 @@ export class FeatureFillLayer extends VectorStyleLayer
 
     paintStyle(options: StylingOptions, changes=false)
     {
-        const coloured = options.coloured || true
+        const coloured = !('coloured' in options) || options.coloured
         const dimmed = options.dimmed || false
         const functional = (options.flatmapStyle === FLATMAP_STYLE.FUNCTIONAL)
         const paintStyle: PaintSpecification = {
@@ -397,8 +397,8 @@ export class FeatureBorderLayer extends VectorStyleLayer
 
     paintStyle(options: StylingOptions, changes=false)
     {
-        const coloured = options.coloured || true
-        const outlined = options.outlined || true
+        const coloured = !('coloured' in options) || options.coloured
+        const outlined = !('outlined' in options) || options.outlined
         const dimmed = options.dimmed || false
         const activeRasterLayer = options.activeRasterLayer || false
         const functional = (options.flatmapStyle === FLATMAP_STYLE.FUNCTIONAL)
@@ -490,7 +490,7 @@ export class FeatureLineLayer extends VectorStyleLayer
 
     paintStyle(options: StylingOptions, changes=false)
     {
-        const coloured = options.coloured || true
+        const coloured = !('coloured' in options) || options.coloured
         const paintStyle: PaintSpecification = {
             'line-color': [
                 'case',
@@ -1323,7 +1323,7 @@ export class RasterStyleLayer extends StyleLayer
 
     style(layer: FlatMapLayer, options: StylingOptions): RasterLayerSpecification
     {
-        const coloured = options.coloured || true
+        const coloured = !('coloured' in options) || options.coloured
         const style: RasterLayerSpecification = {
             ...super.style(layer),
             source: this.id,


### PR DESCRIPTION
I've found that the `outline` option is not working in the `setPaint` method, and is changed from `outline` to `outlined`. However, it is still not working because `options.outlined || true` will always return `true` unless `outlined` is not a `falsy` value. So, I've updated those to fix the issue with both `outlined` and `coloured` options. 