### PR TITLE
Cluster marker terms issue

### DIFF
--- a/src/layers/acluster.ts
+++ b/src/layers/acluster.ts
@@ -151,7 +151,8 @@ export class ClusteredAnatomicalMarkerLayer
     markerTerms(term: string): DatasetMarkerResult[]
     //==============================================
     {
-        const terms = [...(this.#markerTerms.get(term) || []).values()]
+        const zoomLevel = Math.floor(this.#map.getZoom())
+        const terms = [...(this.#markerTermsByZoomTerm.get(term)[zoomLevel] || []).values()]
         return terms.map(term => {
             let label: string = term
             const termFeatures = this.#flatmap.modelFeatureIds(term)


### PR DESCRIPTION
Currently, clicking on some markers does not display the correct number of datasets in the sidebar. This issue occurs because the `markerTerms` map is not dynamically generated based on the current zoom level. It always returns the same set of terms. As a result, the sidebar filter may be set with incorrect facets sometimes.
The issue is described in the Wrike [ticket](https://www.wrike.com/open.htm?id=1574570696).

I created a new `markerTermsByZoomTerm` map that stores terms specific to each zoom level. The original `markerTerms` map is retained for potential future use.

<img width="932" alt="Screenshot 2025-06-10 at 2 26 44 PM" src="https://github.com/user-attachments/assets/5dc86349-9373-4147-a852-33fd7d4d1854" />
