### PR TITLE
Optional reset selected paths view

### DIFF
--- a/src/flatmap.ts
+++ b/src/flatmap.ts
@@ -592,17 +592,17 @@ export class FlatMap
     }
 
     /**
-     * Enables or disables resetting the paths and features when clicking on an empty area.
+     * Enable or disable reset selected features when click on an empty area.
      *
      * @param {boolean} enable Whether to enable the reset behavior.
-     *                         When enabled, clicking on empty space will reset the view.
+     *                         When enabled, click on empty space will reset the view.
      *                         Defaults to ``true`` (enable)
      */
-    enableResetOnClick(enable=true)
-    //==================================================================
+    enableFeatureResetOnClick(enable=true)
+    //====================================
     {
         if (this.#userInteractions !== null) {
-            this.#userInteractions.enableResetOnClick(enable)
+            this.#userInteractions.enableFeatureResetOnClick(enable)
         }
     }
 

--- a/src/flatmap.ts
+++ b/src/flatmap.ts
@@ -592,6 +592,21 @@ export class FlatMap
     }
 
     /**
+     * Enables or disables resetting the paths and features when clicking on an empty area.
+     *
+     * @param {boolean} enable Whether to enable the reset behavior.
+     *                         When enabled, clicking on empty space will reset the view.
+     *                         Defaults to ``true`` (enable)
+     */
+    enableResetOnClick(enable=true)
+    //==================================================================
+    {
+        if (this.#userInteractions !== null) {
+            this.#userInteractions.enableResetOnClick(enable)
+        }
+    }
+
+    /**
      * Load images and patterns/textures referenced in style rules.
      *
      * @private

--- a/src/interactions.ts
+++ b/src/interactions.ts
@@ -193,6 +193,7 @@ export class UserInteractions
     #systemsManager: SystemsManager
     #taxonFacet: TaxonFacet
     #tooltip: maplibregl.Popup|null = null
+    #resetOnClickEnabled: boolean = true
 
     constructor(flatmap: FlatMap)
     {
@@ -1351,17 +1352,21 @@ export class UserInteractions
 
         let clickedFeatures = this.#renderedFeatures(event.point)
         if (clickedFeatures.length == 0) {
-            this.unselectFeatures()
+            if (this.#resetOnClickEnabled) {
+                this.unselectFeatures()
+            }
             return
         }
         const clickedDrawnFeatures = clickedFeatures.filter((f) => !f.id)
         clickedFeatures = clickedFeatures.filter((f) => f.id)
         const clickedFeature = clickedFeatures[0]
         if (this.#modal) {
-            // Remove tooltip, reset active features, etc
-            this.#resetFeatureDisplay()
-            this.unselectFeatures()
-            this.#clearModal()
+            if (this.#resetOnClickEnabled) {
+                // Remove tooltip, reset active features, etc
+                this.#resetFeatureDisplay()
+                this.unselectFeatures()
+                this.#clearModal()
+            }
         } else if (clickedDrawnFeatures.length > 0) {
             // Layer of existing drawn features
             const clickedOnColdLayer = clickedDrawnFeatures.filter((f) => f.source === 'mapbox-gl-draw-cold')[0]
@@ -1513,6 +1518,12 @@ export class UserInteractions
     {
         this.#taxonFacet.enable(Array.isArray(taxonIds) ? taxonIds : [taxonIds], enable)
         this.#layerManager.refresh()
+    }
+
+    enableResetOnClick(enable=true)
+    //=============================
+    {
+        this.#resetOnClickEnabled = enable
     }
 
     excludeAnnotated(exclude=false)

--- a/src/interactions.ts
+++ b/src/interactions.ts
@@ -1521,7 +1521,7 @@ export class UserInteractions
     }
 
     enableFeatureResetOnClick(enable=true)
-    //=============================
+    //====================================
     {
         this.#resetOnClickEnabled = enable
     }

--- a/src/interactions.ts
+++ b/src/interactions.ts
@@ -1520,7 +1520,7 @@ export class UserInteractions
         this.#layerManager.refresh()
     }
 
-    enableResetOnClick(enable=true)
+    enableFeatureResetOnClick(enable=true)
     //=============================
     {
         this.#resetOnClickEnabled = enable


### PR DESCRIPTION
Provide a function to manually control the selected features view reset when clicking on the background (empty space).

This will be used to support the interaction between Flatmap and the sidebar Connectivity Explorer. Make sure that when the search is applied, highlighted paths/features will not be unselected.