### PR TITLE
Fix annotation popup close error #62

### DIFF
--- a/src/flatmap-types.ts
+++ b/src/flatmap-types.ts
@@ -397,6 +397,7 @@ export type FlatMapMarkerOptions = maplibregl.MarkerOptions & {
 
 export type FlatMapPopUpOptions = maplibregl.PopupOptions & {
     annotationFeatureGeometry?: Point2D
+    annotationEvent?: AnnotationEvent
     positionAtLastClick?: boolean
     preserveSelection?: boolean
 }

--- a/src/interactions.ts
+++ b/src/interactions.ts
@@ -985,7 +985,19 @@ export class UserInteractions
             this.#currentPopup = new maplibregl.Popup(options).addTo(this.#map)
             this.#currentPopup.on('close', this.#onCloseCurrentPopup.bind(this))
             if (drawn) {
-                this.#currentPopup.on('close', this.abortAnnotationEvent.bind(this))
+                // If annotationEvent is not provided, create a fallback with available geometry
+                const fallbackAnnotationEvent: AnnotationEvent = {
+                    type: 'created',
+                    feature: {
+                        id: featureId,
+                        geometry: {
+                            type: 'Point',
+                            coordinates: options.annotationFeatureGeometry!
+                        } as GeoJSON.Point,
+                    } as AnnotatedFeature
+                }
+                const annotationEvent: AnnotationEvent = options.annotationEvent || fallbackAnnotationEvent;
+                this.#currentPopup.on('close', () => this.abortAnnotationEvent(annotationEvent))
             }
             this.#currentPopup.setLngLat(location)
             if (typeof content === 'object') {


### PR DESCRIPTION
Fixed annotation popup close error #62 by adding `annotationEvent` from popup event and a fallback.
