### PR TITLE
Adjust nerve cuff behavior for active and selected states

### DIFF
--- a/src/layers/styling.ts
+++ b/src/layers/styling.ts
@@ -70,7 +70,7 @@ export interface StylingOptions extends StyleLayerOptions
 
 const COLOUR_ACTIVE    = 'blue'
 const COLOUR_ANNOTATED = '#C8F'
-const COLOUR_SELECTED  = '#0F0'
+const COLOUR_SELECTED  = '#8EF35D'
 const COLOUR_HIDDEN    = '#D8D8D8'
 
 const CENTRELINE_ACTIVE = '#888'
@@ -356,7 +356,7 @@ export class FeatureFillLayer extends VectorStyleLayer
             'fill-opacity': [
                 'case',
                 ['boolean', ['feature-state', 'hidden'], false], 0.01,
-                ['boolean', ['feature-state', 'selected'], false], 0.2,
+                ['boolean', ['feature-state', 'selected'], false], 1.0,
                 ['has', 'opacity'], ['get', 'opacity'],
                 ['has', 'colour'], 1.0,
                 ['==', ['get', 'kind'], 'proxy'], 1.0,
@@ -1125,7 +1125,7 @@ export class NervePolygonFill extends VectorStyleLayer
             'fill-opacity': [
                 'case',
                 ['boolean', ['feature-state', 'hidden'], false], 0.01,
-                ['boolean', ['feature-state', 'selected'], false], 0.2,
+                ['boolean', ['feature-state', 'selected'], false], 1,
                 ['has', 'opacity'], ['get', 'opacity'],
                 ['has', 'colour'], 1.0,
                 ['==', ['get', 'kind'], 'proxy'], 1.0,


### PR DESCRIPTION
Issue #68 

This PR updates the visual behavior of nerve cuffs to be consistent with other features:

- Border color and stroke width now match other features: blue when active, black when selected.
- Selected feature colors are now consistent across the map: COLOUR_SELECTED is set to #8EF35D with opacity 1.0, matching the appearance used for ganglia (where #0F0 at 0.2 opacity blends with the #B2F074 background).
- Nerve cuff (both border and polygon) opacity is reduced when dimmed for clearer de-emphasis.