### PR TITLE
Fix `mouseenter` event callback data for overlapping line features 

### DIFF
--- a/src/interactions.ts
+++ b/src/interactions.ts
@@ -1381,7 +1381,6 @@ export class UserInteractions
             return
         }
 
-        // Determine the primary feature and any line features for tooltip
         const feature = features[0]
         const lineFeatures = features.filter(f => ('centreline' in f.properties
                                                  || ('type' in f.properties
@@ -1398,7 +1397,6 @@ export class UserInteractions
 
         // Simulate `mouseenter` events on features
         // When multiple line (path) features overlap, emit all of them
-        // so the callback can provide labels for each one.
         if (lineFeatures.length > 1) {
             const firstLineFeature = lineFeatures[0]
             const firstFeatureId = isMarker(firstLineFeature) ? +firstLineFeature.id

--- a/src/interactions.ts
+++ b/src/interactions.ts
@@ -1381,31 +1381,69 @@ export class UserInteractions
             return
         }
 
-        // Simulate `mouseenter` events on features
-
+        // Determine the primary feature and any line features for tooltip
         const feature = features[0]
-        const featureId: number = isMarker(feature) ? +feature.id
-                                                    : +feature.properties.featureId
-        const featureModels = ('properties' in feature && 'models' in feature.properties)
-                            ? feature.properties.models
-                            : null
-        if (this.#lastFeatureMouseEntered !== featureId
-         && (this.#lastFeatureModelsMouse === null
-          || this.#lastFeatureModelsMouse !== featureModels)) {
-            if (this.#featureEvent('mouseenter', feature,
-                                    this.#locationOnLine(+featureId, lngLat))) {
-                this.#lastFeatureMouseEntered = featureId
-                this.#lastFeatureModelsMouse = featureModels
-            } else {
-                this.#lastFeatureMouseEntered = null
-                this.#lastFeatureModelsMouse = null
+        const lineFeatures = features.filter(f => ('centreline' in f.properties
+                                                 || ('type' in f.properties
+                                                   && f.properties.type.startsWith('line'))))
+                                     .filter((f, index, self) => {
+                                         // Deduplicate: the same feature can appear multiple times
+                                         // when it spans across vector tile boundaries
+                                         const fId = isMarker(f) ? +f.id : +f.properties.featureId
+                                         return index === self.findIndex(g => {
+                                             const gId = isMarker(g) ? +g.id : +g.properties.featureId
+                                             return gId === fId
+                                         })
+                                     })
+
+        // Simulate `mouseenter` events on features
+        // When multiple line (path) features overlap, emit all of them
+        // so the callback can provide labels for each one.
+        if (lineFeatures.length > 1) {
+            const firstLineFeature = lineFeatures[0]
+            const firstFeatureId = isMarker(firstLineFeature) ? +firstLineFeature.id
+                                                               : +firstLineFeature.properties.featureId
+            const firstFeatureModels = ('properties' in firstLineFeature && 'models' in firstLineFeature.properties)
+                                      ? firstLineFeature.properties.models
+                                      : null
+            if (this.#lastFeatureMouseEntered !== firstFeatureId
+             && (this.#lastFeatureModelsMouse === null
+              || this.#lastFeatureModelsMouse !== firstFeatureModels)) {
+                const allFeatureProperties = lineFeatures.map(f =>
+                    Object.assign({}, f.properties, this.#locationOnLine(+f.properties.featureId, lngLat))
+                ) as FlatMapFeatureAnnotation[]
+                if (this.#multiFeatureEvent('mouseenter', allFeatureProperties)) {
+                    this.#lastFeatureMouseEntered = firstFeatureId
+                    this.#lastFeatureModelsMouse = firstFeatureModels
+                } else {
+                    this.#lastFeatureMouseEntered = null
+                    this.#lastFeatureModelsMouse = null
+                }
             }
-        } else if (this.#flatmap.options.style === FLATMAP_STYLE.CENTRELINE
-                && feature.properties.centreline) {
-            if (this.#lastFeatureMouseEntered === featureId) {
-                const location = this.#locationOnLine(+featureId, lngLat)
-                if ('location' in location) {
-                    this.#featureEvent('mousemove', feature, location)
+        } else {
+            const featureId: number = isMarker(feature) ? +feature.id
+                                                        : +feature.properties.featureId
+            const featureModels = ('properties' in feature && 'models' in feature.properties)
+                                ? feature.properties.models
+                                : null
+            if (this.#lastFeatureMouseEntered !== featureId
+             && (this.#lastFeatureModelsMouse === null
+              || this.#lastFeatureModelsMouse !== featureModels)) {
+                if (this.#featureEvent('mouseenter', feature,
+                                        this.#locationOnLine(+featureId, lngLat))) {
+                    this.#lastFeatureMouseEntered = featureId
+                    this.#lastFeatureModelsMouse = featureModels
+                } else {
+                    this.#lastFeatureMouseEntered = null
+                    this.#lastFeatureModelsMouse = null
+                }
+            } else if (this.#flatmap.options.style === FLATMAP_STYLE.CENTRELINE
+                    && feature.properties.centreline) {
+                if (this.#lastFeatureMouseEntered === featureId) {
+                    const location = this.#locationOnLine(+featureId, lngLat)
+                    if ('location' in location) {
+                        this.#featureEvent('mousemove', feature, location)
+                    }
                 }
             }
         }
@@ -1422,9 +1460,6 @@ export class UserInteractions
             this.activateFeature(feature)
             tooltipFeature = feature
         }
-        const lineFeatures = features.filter(feature => ('centreline' in feature.properties
-                                                      || ('type' in feature.properties
-                                                        && feature.properties.type.startsWith('line')) ))
         if (lineFeatures.length > 0) {
             tooltip = this.#lineTooltip(lineFeatures)
             tooltipFeature = lineFeatures[0]

--- a/src/interactions.ts
+++ b/src/interactions.ts
@@ -1381,21 +1381,22 @@ export class UserInteractions
             return
         }
 
+        // Simulate `mouseenter` events on features
+
         const feature = features[0]
-        const lineFeatures = features.filter(f => ('centreline' in f.properties
-                                                 || ('type' in f.properties
-                                                   && f.properties.type.startsWith('line'))))
-                                     .filter((f, index, self) => {
-                                         // Deduplicate: the same feature can appear multiple times
-                                         // when it spans across vector tile boundaries
-                                         const fId = isMarker(f) ? +f.id : +f.properties.featureId
-                                         return index === self.findIndex(g => {
-                                             const gId = isMarker(g) ? +g.id : +g.properties.featureId
-                                             return gId === fId
-                                         })
+        const lineFeatures = features.filter(feature => ('centreline' in feature.properties
+                                                 || ('type' in feature.properties
+                                                   && feature.properties.type.startsWith('line'))))
+                                     .filter((feature, index, self) => {
+                                        // Deduplicate: the same feature can appear multiple times
+                                        // when it spans across vector tile boundaries
+                                        const fId = isMarker(feature) ? +feature.id : +feature.properties.featureId
+                                        return index === self.findIndex(g => {
+                                            const gId = isMarker(g) ? +g.id : +g.properties.featureId
+                                            return gId === fId
+                                        })
                                      })
 
-        // Simulate `mouseenter` events on features
         // When multiple line (path) features overlap, emit all of them
         if (lineFeatures.length > 1) {
             const firstLineFeature = lineFeatures[0]
@@ -1407,8 +1408,8 @@ export class UserInteractions
             if (this.#lastFeatureMouseEntered !== firstFeatureId
              && (this.#lastFeatureModelsMouse === null
               || this.#lastFeatureModelsMouse !== firstFeatureModels)) {
-                const allFeatureProperties = lineFeatures.map(f =>
-                    Object.assign({}, f.properties, this.#locationOnLine(+f.properties.featureId, lngLat))
+                const allFeatureProperties = lineFeatures.map(feature =>
+                    Object.assign({}, feature.properties, this.#locationOnLine(+feature.properties.featureId, lngLat))
                 ) as FlatMapFeatureAnnotation[]
                 if (this.#multiFeatureEvent('mouseenter', allFeatureProperties)) {
                     this.#lastFeatureMouseEntered = firstFeatureId


### PR DESCRIPTION
Fixes #81.

Emit data for multiple overlapping line features during the `mouseenter` event callback.

<img width="581" height="254" alt="image" src="https://github.com/user-attachments/assets/486a60aa-5199-4acc-8762-20c422a3bafc" />
